### PR TITLE
changes IP range to avoid pool errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,9 @@ services:
     image: wikiless:latest
     networks:
       wikiless_net:
-        ipv4_address: 172.21.0.6
+        ipv4_address: 172.30.0.6
     environment:
-      REDIS_HOST: redis://172.21.0.5:6379
+      REDIS_HOST: redis://172.30.0.5:6379
     ports:
       - "8180:8080"
     depends_on:
@@ -17,7 +17,7 @@ services:
     image: "redis:alpine"
     networks:
       wikiless_net:
-        ipv4_address: 172.21.0.5
+        ipv4_address: 172.30.0.5
     ports:
       - "6379"
 
@@ -25,4 +25,4 @@ networks:
   wikiless_net:
     ipam:
       config:
-        - subnet: 172.21.0.0/24
+        - subnet: 172.30.0.0/24


### PR DESCRIPTION
Changed it to avoid this bad boy:
```
Creating network "wikiless-docker_wikiless_net" with the default driver
ERROR: Pool overlaps with other one on this address space
```